### PR TITLE
Add `trunc`, with a polyfill for browsers that don't support it.

### DIFF
--- a/src/Math.js
+++ b/src/Math.js
@@ -24,6 +24,10 @@ exports.exp = Math.exp;
 
 exports.floor = Math.floor;
 
+exports.trunc = Math.trunc || function (n) {
+  return n < 0 ? Math.ceil(n) : Math.floor(n);
+};
+
 exports.log = Math.log;
 
 exports.max = function (n1) {

--- a/src/Math.purs
+++ b/src/Math.purs
@@ -60,6 +60,10 @@ foreign import sqrt :: Number -> Number
 -- | Returns the tangent of the argument.
 foreign import tan :: Radians -> Number
 
+-- | Truncates the decimal portion of a number. Equivalent to `floor` if the
+-- | number is positive, and `ceil` if the number is negative.
+foreign import trunc :: Number -> Number
+
 infixl 7 %
 
 -- | Computes the remainder after division, wrapping Javascript's `%` operator.


### PR DESCRIPTION
Of course, you can implement this in plain-old-purescript, but it's likely that the native browser method is faster, when available. And I've included a polyfill for cases where it's not available (mainly IE, according to this page)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc