### PR TITLE
Clarify what sqrt does

### DIFF
--- a/src/Math.purs
+++ b/src/Math.purs
@@ -54,7 +54,7 @@ foreign import round :: Number -> Number
 -- | Returns the sine of the argument.
 foreign import sin :: Radians -> Number
 
--- | Returns the square root of the argument.
+-- | Returns the non-negative square root of the argument.
 foreign import sqrt :: Number -> Number
 
 -- | Returns the tangent of the argument.


### PR DESCRIPTION
Most real numbers have two square roots. For example, both -2 and 2 are square roots of 4. Specify which one it returns.