### PR TITLE
fround support

### DIFF
--- a/src/Math.js
+++ b/src/Math.js
@@ -56,6 +56,8 @@ exports.remainder = function (n) {
 
 exports.round = Math.round;
 
+exports.fround = Math.fround;
+
 exports.sin = Math.sin;
 
 exports.sqrt = Math.sqrt;

--- a/src/Math.purs
+++ b/src/Math.purs
@@ -51,6 +51,9 @@ foreign import pow :: Number -> Number -> Number
 -- | Returns the integer closest to the argument.
 foreign import round :: Number -> Number
 
+-- | Returns the 32-bit floating point number closest to the argument.
+foreign import fround :: Number -> Number
+
 -- | Returns the sine of the argument.
 foreign import sin :: Radians -> Number
 


### PR DESCRIPTION
`fround` is a _mostly_ implemented ES6 standard across browsers: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround#Browser_compatibility

It rounds high precision floating points to their nearest Float32 value - very useful for WebGL ffi and ArrayBuffer nonsense :)