### PR TITLE
Add the golden ratio φ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 
 New features:
 - Added `imul` (#18)
+- Added the golden ratio `phi` (#29)
 
 Bugfixes:
 

--- a/src/Math.js
+++ b/src/Math.js
@@ -98,6 +98,8 @@ exports.pi = Math.PI;
 
 exports.tau = 2 * Math.PI;
 
+exports.phi = (1 + Math.sqrt(5)) / 2;
+
 exports.sqrt1_2 = Math.SQRT1_2;
 
 exports.sqrt2 = Math.SQRT2;

--- a/src/Math.purs
+++ b/src/Math.purs
@@ -93,6 +93,10 @@ foreign import pi :: Number
 -- | The ratio of the circumference of a circle to its radius, around 6.283185.
 foreign import tau :: Number
 
+-- | The golden ratio, *φ*, around 1.61803. Two quantities `a` and `b` are said
+-- | to be in the *golden ratio φ* if `(a + b) / a = a / b = φ`.
+foreign import phi :: Number
+
 -- | The Square root of one half, around 0.707107.
 foreign import sqrt1_2 :: Number
 


### PR DESCRIPTION
**Description of the change**

Adds the [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) phi as a new mathematical constant.
- Inspired by sharkdp/insect#246
- PR written using #17 as a template 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
